### PR TITLE
html filename (as relevant), prettifying json with python

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Usage
 Go to: https://www.bundesrat.de/DE/bundesrat/mitglieder/mitglieder-node.html?cms_param3=Alle&cms_param2=contact&cms_param1=state-1
-Save page with your browser to de-obfuscate javascript.
+Save page with your browser as `mitglieder.html` to de-obfuscate javascript.
 
 ```
 ./parse.py
@@ -10,9 +10,13 @@ Save page with your browser to de-obfuscate javascript.
 
 edit `bundesrat.json`, change `gender = '?'` to either `m` or `f`.
 
-prettify
+To prettify, either do:
 ```
 jq bundesrat.json > bundesrat_member.json
+```
+or:
+```
+python -m json.tool bundesrat.json > bundesrat_member.json
 ```
 
 # License


### PR DESCRIPTION
* Obviously html needs to be saved as `mitglieder.html`.
* Added prettifying json by python.
`jq` (as of https://github.com/jqlang/jq) may return errors, see one below, but python itself can prettify json (https://docs.python.org/3/library/json.html) in one line.

For example, I got
`jq: error: syntax error, unexpected INVALID_CHARACTER (Windows cmd shell quoting issues?) at <top-level>, line 1:
.\bundesrat.json
jq: error: try .["field"] instead of .field for unusually named fields at <top-level>, line 1:
.\bundesrat.json
jq: 2 compile errors`